### PR TITLE
Indirectly update to libm 0.2

### DIFF
--- a/alga/Cargo.toml
+++ b/alga/Cargo.toml
@@ -19,11 +19,10 @@ default = [ "std" ]
 std = [ ]
 
 [dependencies]
-num-traits  = { version = "0.2", default-features = false }
+num-traits  = { version = "0.2.11", default-features = false, features = ["libm"] }
 approx      = { version = "0.3", default-features = false }
 decimal     = { version = "2.0", default-features = false, optional = true }
 num-complex = { version = "0.2", default-features = false }
-libm        = "0.1"
 
 [dev-dependencies]
 quickcheck  = "0.8"

--- a/alga/src/general/complex.rs
+++ b/alga/src/general/complex.rs
@@ -7,11 +7,7 @@ use std::{f32, f64};
 use crate::general::{Field, JoinSemilattice, MeetSemilattice, RealField, SubsetOf, SupersetOf};
 
 #[cfg(not(feature = "std"))]
-use libm::F32Ext;
-#[cfg(not(feature = "std"))]
-use libm::F64Ext;
-#[cfg(not(feature = "std"))]
-use num;
+use num::Float;
 //#[cfg(feature = "decimal")]
 //use decimal::d128;
 
@@ -474,8 +470,8 @@ macro_rules! impl_complex(
 
 #[cfg(not(feature = "std"))]
 impl_complex!(
-    f32, f32, F32Ext;
-    f64, f64, F64Ext
+    f32, f32, Float;
+    f64, f64, Float
 );
 
 #[cfg(feature = "std")]

--- a/alga/src/general/real.rs
+++ b/alga/src/general/real.rs
@@ -6,11 +6,7 @@ use approx::{RelativeEq, UlpsEq};
 use crate::general::{ComplexField, Lattice};
 
 #[cfg(not(feature = "std"))]
-use libm::F32Ext;
-#[cfg(not(feature = "std"))]
-use libm::F64Ext;
-#[cfg(not(feature = "std"))]
-use num;
+use num::Float;
 //#[cfg(feature = "decimal")]
 //use decimal::d128;
 
@@ -180,7 +176,7 @@ macro_rules! impl_real(
 );
 
 #[cfg(not(feature = "std"))]
-impl_real!(f32,f32,F32Ext; f64,f64,F64Ext);
+impl_real!(f32,f32,Float; f64,f64,Float);
 #[cfg(feature = "std")]
 impl_real!(f32,f32,f32; f64,f64,f64);
 //#[cfg(feature = "decimal")]


### PR DESCRIPTION
Unfortunately, `libm 0.2` removed the `F32Ext` and `F64Ext` extension
traits, which makes it harder to choose the different methods. However,
this was already dealt with in rust-num/num-traits#144 for `Float`, so
we can piggy-back on that here, no longer using `libm` directly.