### PR TITLE
Update num-complex dependency v0.2 -> v0.3

### DIFF
--- a/alga/Cargo.toml
+++ b/alga/Cargo.toml
@@ -22,7 +22,7 @@ std = [ ]
 num-traits  = { version = "0.2.11", default-features = false, features = ["libm"] }
 approx      = { version = "0.3", default-features = false }
 decimal     = { version = "2.0", default-features = false, optional = true }
-num-complex = { version = "0.2", default-features = false }
+num-complex = { version = "0.3", default-features = false }
 
 [dev-dependencies]
 quickcheck  = "0.9"


### PR DESCRIPTION
[Changelog](https://github.com/rust-num/num-complex/blob/master/RELEASES.md#release-030-2020-06-13)