### PR TITLE
Fix some incorrect dependencies in `alga_derive`

### DIFF
--- a/alga_derive/src/lib.rs
+++ b/alga_derive/src/lib.rs
@@ -101,9 +101,9 @@ fn get_closest_trait(tra1t: &str) -> &str {
 fn get_dependencies(tra1t: &str, op: usize) -> Vec<String> {
     match tra1t {
         "Quasigroup" => vec![],
-        "Monoid" => vec!["Quasigroup"],
+        "Monoid" => vec!["Semigroup"],
         "Semigroup" => vec![],
-        "Loop" => vec!["Semigroup"],
+        "Loop" => vec!["Quasigroup"],
         "Group" => vec!["Monoid", "Quasigroup", "Loop", "Semigroup"],
         "GroupAbelian" => vec!["Group", "Monoid", "Quasigroup", "Loop", "Semigroup"],
         _ => match tra1t {
@@ -117,7 +117,7 @@ fn get_dependencies(tra1t: &str, op: usize) -> Vec<String> {
                     "Semigroup",
                 ]
             } else {
-                vec!["Monoid", "Quasigroup", "Loop", "Semigroup"]
+                vec!["Monoid", "Semigroup"]
             },
             "RingCommutative" => if op == 0 {
                 vec![
@@ -130,7 +130,7 @@ fn get_dependencies(tra1t: &str, op: usize) -> Vec<String> {
                     "Semigroup",
                 ]
             } else {
-                vec!["Ring", "Monoid", "Quasigroup", "Loop", "Semigroup"]
+                vec!["Monoid", "Semigroup"]
             },
             "Field" => if op == 0 {
                 vec![


### PR DESCRIPTION
Three small changes. I was unable to get any of the tests in `alga_derive_test` to run (even before modifying things), but in my personal use case (implementing an integral domain, so in particular multiplication does not have two-sided inverses) I have expanded the macro `#[alga_derive(RingCommutative(Additive, Multiplicative))]` and it now behaves as expected.

The total changes are:
1. Fix incorrect dependency of Monoid on Quasigroup and Loop on Semigroup
2. Remove incorrect dependencies of Quasigroup/Loop on the second operation of CommutativeRing (which must only be a semigroup)
3. Remove second instance of Ring on the second operation of CommutativeRing (it led to two AbstractRing definitions which were then conflicting).