### PR TITLE
ignore doctests for non-exported macro_rules! macros

### DIFF
--- a/alga/src/general/one_operator.rs
+++ b/alga/src/general/one_operator.rs
@@ -85,7 +85,7 @@ pub trait AbstractQuasigroup<O: Operator>:
 /// Implements the quasigroup trait for types provided.
 /// # Examples
 ///
-/// ```
+/// ```ignore
 /// # #[macro_use]
 /// # extern crate alga;
 /// # use alga::general::{AbstractMagma, AbstractQuasigroup, Additive, TwoSidedInverse};
@@ -146,7 +146,7 @@ pub trait AbstractSemigroup<O: Operator>: PartialEq + AbstractMagma<O> {
 /// Implements the semigroup trait for types provided.
 /// # Examples
 ///
-/// ```
+/// ```ignore
 /// # #[macro_use]
 /// # extern crate alga;
 /// # use alga::general::{AbstractMagma, AbstractSemigroup, Additive};
@@ -191,7 +191,7 @@ pub trait AbstractLoop<O: Operator>: AbstractQuasigroup<O> + Identity<O> {}
 /// Implements the loop trait for types provided.
 /// # Examples
 ///
-/// ```
+/// ```ignore
 /// # #[macro_use]
 /// # extern crate alga;
 /// # use alga::general::{AbstractMagma, AbstractLoop, Additive, TwoSidedInverse, Identity};
@@ -262,7 +262,7 @@ pub trait AbstractMonoid<O: Operator>: AbstractSemigroup<O> + Identity<O> {
 /// Implements the monoid trait for types provided.
 /// # Examples
 ///
-/// ```
+/// ```ignore
 /// # #[macro_use]
 /// # extern crate alga;
 /// # use alga::general::{AbstractMagma, AbstractMonoid, Additive, Identity};
@@ -299,7 +299,7 @@ pub trait AbstractGroup<O: Operator>: AbstractLoop<O> + AbstractMonoid<O> {}
 /// Implements the group trait for types provided.
 /// # Examples
 ///
-/// ```
+/// ```ignore
 /// # #[macro_use]
 /// # extern crate alga;
 /// # use alga::general::{AbstractMagma, AbstractGroup, Additive, TwoSidedInverse, Identity};
@@ -369,7 +369,7 @@ pub trait AbstractGroupAbelian<O: Operator>: AbstractGroup<O> {
 /// Implements the Abelian group trait for types provided.
 /// # Examples
 ///
-/// ```
+/// ```ignore
 /// # #[macro_use]
 /// # extern crate alga;
 /// # use alga::general::{AbstractMagma, AbstractGroupAbelian, Additive, TwoSidedInverse, Identity};

--- a/alga/src/general/two_operators.rs
+++ b/alga/src/general/two_operators.rs
@@ -68,7 +68,7 @@ pub trait AbstractRing<A: Operator = Additive, M: Operator = Multiplicative>:
 /// Implements the ring trait for types provided.
 /// # Examples
 ///
-/// ```
+/// ```ignore
 /// # #[macro_use]
 /// # extern crate alga;
 /// # use alga::general::{AbstractMagma, AbstractRing, Additive, Multiplicative, TwoSidedInverse, Identity};
@@ -158,7 +158,7 @@ pub trait AbstractRingCommutative<A: Operator = Additive, M: Operator = Multipli
 /// Implements the commutative ring trait for types provided.
 /// # Examples
 ///
-/// ```
+/// ```ignore
 /// # #[macro_use]
 /// # extern crate alga;
 /// # use alga::general::{AbstractMagma, AbstractRingCommutative, Additive, Multiplicative, TwoSidedInverse, Identity};
@@ -218,7 +218,7 @@ pub trait AbstractField<A: Operator = Additive, M: Operator = Multiplicative>:
 /// Implements the field trait for types provided.
 /// # Examples
 ///
-/// ```
+/// ```ignore
 /// # #[macro_use]
 /// # extern crate alga;
 /// # use alga::general::{AbstractMagma, AbstractField, Additive, Multiplicative, TwoSidedInverse, Identity};

--- a/alga/src/macros.rs
+++ b/alga/src/macros.rs
@@ -16,7 +16,7 @@
 /// Implements empty traits aka marker traits for types provided.
 /// # Examples
 ///
-/// ```
+/// ```ignore
 /// # #[macro_use]
 /// # extern crate alga;
 /// # fn main() {}
@@ -24,7 +24,7 @@
 /// struct Struct;
 /// impl_marker!(Marker; u32; Struct);
 /// ```
-/// ```
+/// ```ignore
 /// # #[macro_use]
 /// # extern crate alga;
 /// # use std::fmt::Debug;


### PR DESCRIPTION
This fixes building doctests with Rust 1.62, which now actually runs doctests for non-exported macros:

https://github.com/rust-lang/rust/issues/97030
